### PR TITLE
Fix password change success message

### DIFF
--- a/Views/Account/Profile.cshtml
+++ b/Views/Account/Profile.cshtml
@@ -47,7 +47,7 @@
     @if (ViewData["result"] != null && ViewData["result"] == "PasswordChanged")
     {
         <script>
-            toastr["success"]("Password has been changed..", "Password changed!");
+            toastr["success"]("Password has been changed.", "Password changed!");
         </script>
     }
 }


### PR DESCRIPTION
## Summary
- remove stray period from password change notification

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository '...' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892e20a7f7c8327b9e651842c667a9b